### PR TITLE
fix: remove apt-get upgrade from pdf-prep-force to fix CI snap failure

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -169,7 +169,6 @@ pdf-prep: install
 
 pdf-prep-force:
 	apt-get update
-	apt-get upgrade -y
 	apt-get install --no-install-recommends -y $(DOCS_PDFPACKAGES) \
 
 pdf: pdf-prep


### PR DESCRIPTION
## Summary

Removes the `apt-get upgrade -y` line from the `pdf-prep-force` target in `docs/Makefile`. This line was causing CI failures on the PDF dependencies installation step.

## Root cause

`apt-get upgrade -y` upgrades **all** system packages, not just the PDF-related ones. On the GitHub Actions `ubuntu-latest` runner, this pulls in a new version of the `firefox` package. In Ubuntu 24.04, `firefox` is a transitional package that depends on the **firefox snap**, and snapd doesn't work properly in the containerized CI environment — hence:

```
Errors were encountered while processing:
 /tmp/apt-dpkg-install-Z28U0P/02-firefox_1%3a1snap1-0ubuntu5_amd64.deb
E: Sub-process /usr/bin/dpkg returned an error code (1)
```

This is an environmental failure: whenever a new firefox snap version is published in the Ubuntu archive, `apt-get upgrade` tries (and fails) to install it.

## The fix

The `apt-get upgrade -y` line is unnecessary for PDF generation — you only need to *install* the PDF packages, not upgrade the entire system. Removing it makes CI deterministic and avoids snap-related failures.

```diff
 pdf-prep-force:
 	apt-get update
-	apt-get upgrade -y
 	apt-get install --no-install-recommends -y $(DOCS_PDFPACKAGES) \
```
