### PR TITLE
fix: exclude `_build` dir when linting Markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@
 * Make removed URL check redirect-aware and add support for reusable workflow contexts
 * Exclude utility directories from builds and checks
 * Update link to documentation in README
+* Exclude `_build` dir when linting Markdown
 
 ### Changed
 
 * `docs/conf.py` [#610](https://github.com/canonical/sphinx-stack/pull/610)
-* `docs/Makefile` [#605](https://github.com/canonical/sphinx-stack/pull/605), [#610](https://github.com/canonical/sphinx-stack/pull/610)
+* `docs/Makefile` [#605](https://github.com/canonical/sphinx-stack/pull/605), [#610](https://github.com/canonical/sphinx-stack/pull/610), [#628](https://github.com/canonical/sphinx-stack/pull/628)
 * `README.md` [#603](https://github.com/canonical/sphinx-stack/pull/603)
 * `.github/workflows/cla-check.yml` [#606](https://github.com/canonical/sphinx-stack/pull/606)
 * `.github/workflows/check-removed-urls.yml` [#612](https://github.com/canonical/sphinx-stack/pull/#612)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -116,11 +116,7 @@ lint-md: pymarkdownlnt-install
 	@. $(DOCS_VENV); pymarkdownlnt \
 		--config $(DEV_DIR)/.pymarkdown.json \
 		--return-code-scheme explicit \
-		scan \
-			--recurse \
-			--exclude=$(DEV_DIR)/** \
-			--exclude=$(DOCS_VENVDIR)/** \
-			$(DOCS_SOURCEDIR); \
+		scan --recurse $(CHECK_PATH); \
 	status=$$?; \
 	if [ $$status -eq 1 ]; then \
 		echo "No Markdown files selected for linting"; \


### PR DESCRIPTION
- [x] Have you updated `CHANGELOG.md` with relevant non-documentation file changes?
- [ ] Have you updated the documentation for this change?

-----

Update the `lint-md` target to run on `CHECK_FILES` like the other checks. Resolves https://github.com/canonical/sphinx-stack/issues/626.