### PR TITLE
build(deps): pin Vale to 3.13.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 
 * `docs/conf.py`  [#562](https://github.com/canonical/sphinx-docs-starter-pack/pull/562), [#576](https://github.com/canonical/sphinx-docs-starter-pack/pull/576), [#590](https://github.com/canonical/sphinx-docs-starter-pack/pull/590), [#595](https://github.com/canonical/sphinx-docs-starter-pack/pull/595), [#598](https://github.com/canonical/sphinx-docs-starter-pack/pull/598)
 * `docs/Makefile` [#575](https://github.com/canonical/sphinx-docs-starter-pack/pull/575), [#590](https://github.com/canonical/sphinx-docs-starter-pack/pull/590)
-* `docs/requirements.txt` [#590]([#590](https://github.com/canonical/sphinx-docs-starter-pack/pull/590))
+* `docs/requirements.txt` [#590]([https://github.com/canonical/sphinx-docs-starter-pack/pull/590), [#630]([https://github.com/canonical/sphinx-docs-starter-pack/pull/630)
 * `docs/reuse/` [#576](https://github.com/canonical/sphinx-docs-starter-pack/pull/576)
 * `docs/.sphinx/` [#598](https://github.com/canonical/sphinx-docs-starter-pack/pull/598)
 * `docs/_templates/footer.html` [#594](https://github.com/canonical/sphinx-docs-starter-pack/pull/594)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -31,4 +31,4 @@ sphinx-llm~=0.4
 
 # Vale dependencies
 rst2html
-vale~=3.13
+vale~=3.13.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -31,4 +31,4 @@ sphinx-llm~=0.4
 
 # Vale dependencies
 rst2html
-vale~=3.13.0
+vale==3.13.0.0


### PR DESCRIPTION
- [X] Have you updated `CHANGELOG.md` with relevant non-documentation file changes?
- [ ] Have you updated the documentation for this change?

-----
New Vale failure points don't constitute a breaking change in the upstream package, so we should pin it to a minor version for consistency.

Resolves https://github.com/canonical/sphinx-stack/issues/625.