### PR TITLE
Allow documentation check jobs to be required for merge

### DIFF
--- a/.github/workflows/automatic-doc-checks.yml
+++ b/.github/workflows/automatic-doc-checks.yml
@@ -5,8 +5,8 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    paths:
-      - 'docs/**'   # Only run on changes to the docs directory
+    branches:
+    - '*'
 
   workflow_dispatch:
     # Manual trigger
@@ -16,7 +16,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Detect changes as a job to avoid skipped workflows blocking merges
+  changes:
+    uses: ./.github/workflows/detect-docs-changes.yml
+
   documentation-checks:
+    needs: changes
+    if: needs.changes.outputs.docs == 'true'
     uses: canonical/documentation-workflows/.github/workflows/documentation-checks.yaml@main
     with:
       working-directory: "docs"

--- a/.github/workflows/detect-docs-changes.yml
+++ b/.github/workflows/detect-docs-changes.yml
@@ -1,0 +1,46 @@
+name: Detect docs/** changes
+
+# Reusable workflow to determine if a push or pull request needs to run
+# checks under `docs/`.
+#
+# We deliberately do not use a `paths:` filter on the callers' triggers.
+#
+# When a workflow backing a required status check is skipped because of a
+# `paths:` filter, GitHub can't tell "skipped" apart from "hasn't run yet".
+# The check gets stuck as "Expected — Waiting for status to be reported" on PRs
+# that don't touch those paths. This blocks the merge.
+#
+# Instead, the callers are always triggered and use this to skip the majority of
+# the job (but still report a status).
+
+on:
+  workflow_call:
+    outputs:
+      docs:
+        description: "'true' if docs/** changed (or the event can't be diffed)"
+        value: ${{ jobs.detect.outputs.docs }}
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      docs: ${{ steps.filter.outputs.docs }}
+    steps:
+    - uses: actions/checkout@v5
+      with:
+        fetch-depth: 0
+    - name: Check for changes in docs/
+      id: filter
+      run: |
+        if [ "${{ github.event_name }}" = "pull_request" ]; then
+          range="${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}"
+        elif [ "${{ github.event_name }}" = "push" ]; then
+          range="${{ github.event.before }}...${{ github.event.after }}"
+        else
+          range=""
+        fi
+        if [ -z "$range" ] || git diff --name-only "$range" | grep -q '^docs/'; then
+          echo "docs=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "docs=false" >> "$GITHUB_OUTPUT"
+        fi

--- a/.github/workflows/markdown-style-checks.yml
+++ b/.github/workflows/markdown-style-checks.yml
@@ -10,11 +10,15 @@ on:
   pull_request:
     branches:
     - '*'
-    paths:
-    - 'docs/**'   # Only run on changes to the docs directory
 
 jobs:
+  # Detect changes as a job to avoid skipped workflows blocking merges
+  changes:
+    uses: ./.github/workflows/detect-docs-changes.yml
+
   markdown-lint:
+    needs: changes
+    if: needs.changes.outputs.docs == 'true'
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Exclude utility directories from builds and checks
 * Update link to documentation in README
 * Skip pa11y installation if it is already present
+* Fix using `markdown-lint` and `documentation-checks` as hard merge requirements
 
 ### Changed
 
@@ -14,6 +15,8 @@
 * `README.md` [#603](https://github.com/canonical/sphinx-stack/pull/603)
 * `.github/workflows/cla-check.yml` [#606](https://github.com/canonical/sphinx-stack/pull/606)
 * `.github/workflows/check-removed-urls.yml` [#612](https://github.com/canonical/sphinx-stack/pull/#612)
+* `.github/workflows/automatic-doc-checks.yml` [#633](https://github.com/canonical/sphinx-stack/pull/633)
+* `.github/workflows/markdown-style-checks.yml` [#633](https://github.com/canonical/sphinx-stack/pull/633)
 
 ## 2.0
 


### PR DESCRIPTION
This has been a long-standing pain point with one of our internal repos. We include `markdown-lint` and `documentation-checks` in the merge requirements for our `main` branch. PRs that don't modify files under `docs/**` will end up with merge requirements that can never be satisfied:

<img width="827" height="667" alt="image" src="https://github.com/user-attachments/assets/847b1d5c-0b80-45db-8fe3-2c97ddae0062" />

This is due to a github limitation (merge requirements can't tell if a check was skipped vs if it was run at all).

This also applies to pushes/force-pushes that don't modify stuff under `docs/**`, even if other commits on the same branch/PR do.

The implementation I've proposed here is a bit of a nasty hack and still consumes more CI minutes that skipping the job in the workflow's triggers.

We're likely to merge this in our project but I wanted to forward it in case other projects are seeing similar issues and this is a direction the docs team wants to go.

-----

- [x] Have you updated `CHANGELOG.md` with relevant non-documentation file changes?
- [ ] Have you updated the documentation for this change?